### PR TITLE
update union pay validation rule

### DIFF
--- a/lib/credit_card_validations/card_rules.rb
+++ b/lib/credit_card_validations/card_rules.rb
@@ -57,7 +57,7 @@ module CreditCardValidations
 
         # Luhn validation are skipped for union pay cards because they have unknown generation algoritm
         unionpay: [
-            {length: [16, 17, 18, 19], prefixes: ['622', '624', '625', '626', '628'], skip_validation: true}
+            {length: [16, 17, 18, 19], prefixes: ['62'], skip_validation: true}
         ],
 
         dankrot: [

--- a/test/credit_card_validations_test.rb
+++ b/test/credit_card_validations_test.rb
@@ -26,11 +26,11 @@ class CreditCardValidationsTest < MiniTest::Test
       maestro:    ['6759 6498 2643 8453'],
       jcb:        ['3575 7591 5225 4876', '3566002020360505' ],
       solo:       ['6767 6222 2222 2222 222'],
-      unionpay:   ['6264-1852-1292-2132-067', '6288997715452584', '6269 9920 5813 4322'],
+      unionpay:   ['6264-1852-1292-2132-067', '6288997715452584', '6269 9920 5813 4322', '6214873948568723098'],
       dankrot:    ['5019717010103742']
     }
   end
-  
+
   def test_card_brand_detection
     @test_numbers.each do |key, value|
       value.each do |card_number|
@@ -39,21 +39,21 @@ class CreditCardValidationsTest < MiniTest::Test
       end
     end
   end
-  
+
   def test_card_brand_is_nil_if_credit_card_invalid
     assert_nil detector('1111111111111111').brand
   end
-  
+
   def test_card_brand_detection_with_restriction
     @test_numbers.slice(:visa, :mastercard).each do |key, value|
       assert_equal key, detector(value.first).brand(:visa, :mastercard)
     end
-    
+
     @test_numbers.except(:visa, :mastercard).each do |key, value|
       assert_nil detector(value.first).brand(:visa, :mastercard)
     end
   end
-  
+
   def test_card_valid_method
     @test_numbers.each do |key, value|
       value.each do |card_number|


### PR DESCRIPTION
- the original rule is too restrictive, china union pay card number prefix should be just '62'
