### PR TITLE
Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # CreditCardValidations
 
-[![Build Status](http://img.shields.io/travis/Fivell/credit_card_validations.svg)](https://travis-ci.org/Fivell/credit_card_validations)
+[![Build Status](http://img.shields.io/travis/didww/credit_card_validations.svg)](https://travis-ci.org/didww/credit_card_validations)
 [![Coverage Status](http://img.shields.io/coveralls/Fivell/credit_card_validations.svg)](https://coveralls.io/r/Fivell/credit_card_validations)
 [![Gem Version](http://img.shields.io/gem/v/credit_card_validations.svg)](https://rubygems.org/gems/credit_card_validations)
-[![License](http://img.shields.io/:license-mit-blue.svg)](http://Fivell.mit-license.org)
+[![License](http://img.shields.io/:license-mit-blue.svg)](http://didww.mit-license.org)
 
 
 Gem adds validator  to check whether or not a given number actually falls within the ranges of possible numbers prior to performing such verification, and, as such, CreditCardValidations simply verifies that the credit card number provided is well-formed.

--- a/credit_card_validations.gemspec
+++ b/credit_card_validations.gemspec
@@ -10,8 +10,14 @@ Gem::Specification.new do |gem|
   gem.email         = ["fedoronchuk@gmail.com"]
   gem.description   = %q{A ruby gem for validating credit card numbers}
   gem.summary       = "gem should be used for credit card numbers validation, card brands detections, luhn checks"
-  gem.homepage      = "http://fivell.github.io/credit_card_validations/"
+  gem.homepage      = "http://didww.github.io/credit_card_validations/"
   gem.license       = "MIT"
+  
+  s.metadata    = {
+    'bug_tracker_uri'   => 'https://github.com/didww/credit_card_validations/issues',
+    'changelog_uri'     => 'https://github.com/didww/credit_card_validations/blob/master/Changelog.md',
+    'source_code_uri'   => 'https://github.com/didww/credit_card_validations'
+  }
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/credit_card_validations.gemspec
+++ b/credit_card_validations.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "http://didww.github.io/credit_card_validations/"
   gem.license       = "MIT"
   
-  s.metadata    = {
+  gem.metadata    = {
     'bug_tracker_uri'   => 'https://github.com/didww/credit_card_validations/issues',
     'changelog_uri'     => 'https://github.com/didww/credit_card_validations/blob/master/Changelog.md',
     'source_code_uri'   => 'https://github.com/didww/credit_card_validations'


### PR DESCRIPTION
It is currently impossible to navigate from the RubyGems.org page https://rubygems.org/gems/credit_card_validations to to GitHub repo