### PR TITLE
Test against ruby3 and ignore 2.1.10 result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       rvm: 2.5.3
     - gemfile: gemfiles/rails1-4.gemfile
       rvm: 2.6.3
+     - gemfile: gemfiles/rails1-4.gemfile
+      rvm: 3.0.0
   allow_failures:
     - rvm: 2.1.10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.3
+  - 3.0.0
   - jruby-9.1.15.0
 gemfile:
   - gemfiles/rails1-4.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ matrix:
       rvm: 2.5.3
     - gemfile: gemfiles/rails1-4.gemfile
       rvm: 2.6.3
-
+  allow_failures:
+    - rvm: 2.1.10
 
 before_install:
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true

--- a/credit_card_validations.gemspec
+++ b/credit_card_validations.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activesupport", ">= 3", "<= 6.2"
 
 
+  gem.add_development_dependency "minitest", '~> 5.14.3'
   gem.add_development_dependency "mocha", '1.1.0'
   gem.add_development_dependency 'rake', '~> 10'
 

--- a/spec/active_model_spec.rb
+++ b/spec/active_model_spec.rb
@@ -9,9 +9,9 @@ describe 'ActiveModel Validator' do
        card = model.dup
        card.card_type = 'Master Card'
        card.number6 =  CreditCardValidations::Factory.random(:visa)
-       card.valid?.must_equal false
+       expect(card.valid?).must_equal false
        card.number6 =  CreditCardValidations::Factory.random(:mastercard)
-       card.valid?.must_equal true
+       expect(card.valid?).must_equal true
     end
   end
 
@@ -22,7 +22,7 @@ describe 'ActiveModel Validator' do
           card = model
           card.number4 = number
           card.number5 = number
-          card.valid?.must_equal true
+          expect(card.valid?).must_equal true
         end
       end
     end
@@ -33,8 +33,8 @@ describe 'ActiveModel Validator' do
       VALID_NUMBERS.except(:amex, :maestro).each do |_, numbers|
         card = model
         card.number = numbers.first
-        card.valid?.must_equal false
-        card.errors[:number].include?(card.errors.generate_message(:number, :invalid)).must_equal true
+        expect(card.valid?).must_equal false
+        expect(card.errors[:number].include?(card.errors.generate_message(:number, :invalid))).must_equal true
       end
     end
 
@@ -42,7 +42,7 @@ describe 'ActiveModel Validator' do
       VALID_NUMBERS.except(:amex, :maestro).each do |_, numbers|
         card = model
         card.number3 = numbers.first
-        card.valid?.must_equal true
+        expect(card.valid?).must_equal true
       end
     end
   end
@@ -53,7 +53,7 @@ describe 'ActiveModel Validator' do
         card = model
         card.number = numbers.first
         card.number2 = numbers.first
-        card.valid?.must_equal true
+        expect(card.valid?).must_equal true
       end
     end
   end
@@ -62,8 +62,8 @@ describe 'ActiveModel Validator' do
     it 'should allow custom message' do
       card = model
       card.number7 =  'wrong'
-      card.valid?.must_equal false
-      card.errors[:number7].must_equal ['Custom message']
+      expect(card.valid?).must_equal false
+      expect(card.errors[:number7]).must_equal ['Custom message']
     end
   end
 

--- a/spec/credit_card_validations_spec.rb
+++ b/spec/credit_card_validations_spec.rb
@@ -10,7 +10,7 @@ describe CreditCardValidations do
   describe 'MMI' do
     it 'should detect issuer category' do
       d = detector(VALID_NUMBERS[:visa].first)
-      d.issuer_category.must_equal CreditCardValidations::Mmi::ISSUER_CATEGORIES[d.number[0]]
+      expect(d.issuer_category).must_equal CreditCardValidations::Mmi::ISSUER_CATEGORIES[d.number[0]]
     end
   end
 
@@ -20,17 +20,17 @@ describe CreditCardValidations do
     }
     it 'should call Luhn.valid? once' do
       CreditCardValidations::Luhn.expects(:valid?).with(card_detector.number).once
-      card_detector.valid?(:visa, :unionpay).must_equal true
+      expect(card_detector.valid?(:visa, :unionpay)).must_equal true
     end
 
     it 'should call Luhn.valid? twice' do
       CreditCardValidations::Luhn.expects(:valid?).with(card_detector.number).twice
-      card_detector.valid?(:visa, :mastercard).must_equal false
+      expect(card_detector.valid?(:visa, :mastercard)).must_equal false
     end
 
     it 'should not call Luhn.valid?' do
       CreditCardValidations::Luhn.expects(:valid?).never
-      card_detector.valid?(:unionpay).must_equal true
+      expect(card_detector.valid?(:unionpay)).must_equal true
     end
 
   end
@@ -40,7 +40,7 @@ describe CreditCardValidations do
     VALID_NUMBERS.each do |brand, card_numbers|
       if has_luhn_check_rule?(brand)
         card_numbers.each do |number|
-          luhn_valid?(detector(number).number).must_equal true
+          expect(luhn_valid?(detector(number).number)).must_equal true
         end
       end
     end
@@ -49,32 +49,32 @@ describe CreditCardValidations do
   it 'should check valid brand' do
     VALID_NUMBERS.each do |brand, card_numbers|
       card_numbers.each do |card_number|
-        detector(card_number).send("#{brand}?").must_equal true
-        detector(card_number).brand.must_equal brand
+        expect(detector(card_number).send("#{brand}?")).must_equal true
+        expect(detector(card_number).brand).must_equal brand
       end
     end
   end
 
   it 'should check if card invalid' do
     INVALID_NUMBERS.each do |card_number|
-      detector(card_number).valid?.must_equal false
+      expect(detector(card_number).valid?).must_equal false
       detector(card_number).brand.must_be_nil
       VALID_NUMBERS.keys.each do |brand|
-        detector(card_number).send("#{brand}?").must_equal false
+        expect(detector(card_number).send("#{brand}?")).must_equal false
       end
     end
   end
 
   it 'should detect by full brand name' do
     amex = CreditCardValidations::Factory.random(:amex)
-    detector(amex).valid?('American Express').must_equal true
+    expect(detector(amex).valid?('American Express')).must_equal true
     visa = CreditCardValidations::Factory.random(:visa)
-    detector(visa).valid?('American Express').must_equal false
+    expect(detector(visa).valid?('American Express')).must_equal false
   end
 
   it 'should support multiple brands for single check' do
     VALID_NUMBERS.slice(:visa, :mastercard).each do |key, value|
-      detector(value.first).brand(:visa, :mastercard).must_equal key
+      expect(detector(value.first).brand(:visa, :mastercard)).must_equal key
     end
 
     VALID_NUMBERS.except(:visa, :mastercard).each do |_, value|
@@ -85,20 +85,20 @@ describe CreditCardValidations do
   it 'should check if valid brand without arguments' do
     VALID_NUMBERS.each do |key, value|
       value.each do |card_number|
-        detector(card_number).valid?(key).must_equal true
-        assert detector(card_number).valid?.must_equal true
+        expect(detector(card_number).valid?(key)).must_equal true
+        expect(assert detector(card_number).valid?).must_equal true
       end
     end
   end
 
   it 'should not be valid? if wrong brand' do
-    detector(VALID_NUMBERS[:visa].first).valid?(:mastercard).must_equal false
-    detector(VALID_NUMBERS[:mastercard].first).valid?(:visa).must_equal false
+    expect(detector(VALID_NUMBERS[:visa].first).valid?(:mastercard)).must_equal false
+    expect(detector(VALID_NUMBERS[:mastercard].first).valid?(:visa)).must_equal false
   end
 
   it 'should  be valid? if right brand' do
-    detector(VALID_NUMBERS[:visa].first).valid?(:mastercard, :visa).must_equal true
-    detector(VALID_NUMBERS[:visa].first).valid?(:mastercard, :amex).must_equal false
+    expect(detector(VALID_NUMBERS[:visa].first).valid?(:mastercard, :visa)).must_equal true
+    expect(detector(VALID_NUMBERS[:visa].first).valid?(:mastercard, :amex)).must_equal false
   end
 
 
@@ -110,9 +110,9 @@ describe CreditCardValidations do
 
       it 'should validate number as voyager' do
         CreditCardValidations::Detector.add_brand(:voyager, length: 15, prefixes: '86')
-        detector(voyager_number).valid?(:voyager).must_equal true
-        detector(voyager_number).voyager?.must_equal true
-        detector(voyager_number).brand.must_equal :voyager
+        expect(detector(voyager_number).valid?(:voyager)).must_equal true
+        expect(detector(voyager_number).voyager?).must_equal true
+        expect(detector(voyager_number).brand).must_equal :voyager
       end
 
       describe 'Add voyager rule' do
@@ -121,9 +121,9 @@ describe CreditCardValidations do
         end
 
         it 'should validate number as voyager' do
-          detector(voyager_number).valid?(:voyager).must_equal true
-          detector(voyager_number).voyager?.must_equal true
-          detector(voyager_number).brand.must_equal :voyager
+          expect(detector(voyager_number).valid?(:voyager)).must_equal true
+          expect(detector(voyager_number).voyager?).must_equal true
+          expect(detector(voyager_number).brand).must_equal :voyager
         end
 
         describe 'Remove voyager rule' do
@@ -132,7 +132,7 @@ describe CreditCardValidations do
           end
 
           it 'should not validate number as voyager' do
-            detector(voyager_number).respond_to?(:voyager?).must_equal false
+            expect(detector(voyager_number).respond_to?(:voyager?)).must_equal false
             detector(voyager_number).brand.must_be_nil
           end
         end
@@ -145,11 +145,11 @@ describe CreditCardValidations do
           -> { CreditCardValidations::Factory.random(brand) }.
             must_raise(CreditCardValidations::Error)
           custom_number = 'some_number'
-          detector(custom_number).respond_to?("#{brand}?").must_equal false
+          expect(detector(custom_number).respond_to?("#{brand}?")).must_equal false
           require "credit_card_validations/plugins/#{brand}"
           number = CreditCardValidations::Factory.random(brand)
-          detector(number).valid?("#{brand}".to_sym).must_equal true
-          detector(custom_number).respond_to?("#{brand}?").must_equal true
+          expect(detector(number).valid?("#{brand}".to_sym)).must_equal true
+          expect(detector(custom_number).respond_to?("#{brand}?")).must_equal true
         end
       end
     end

--- a/spec/credit_card_validations_spec.rb
+++ b/spec/credit_card_validations_spec.rb
@@ -58,7 +58,7 @@ describe CreditCardValidations do
   it 'should check if card invalid' do
     INVALID_NUMBERS.each do |card_number|
       expect(detector(card_number).valid?).must_equal false
-      detector(card_number).brand.must_be_nil
+      expect(detector(card_number).brand).must_be_nil
       VALID_NUMBERS.keys.each do |brand|
         expect(detector(card_number).send("#{brand}?")).must_equal false
       end
@@ -78,7 +78,7 @@ describe CreditCardValidations do
     end
 
     VALID_NUMBERS.except(:visa, :mastercard).each do |_, value|
-      detector(value.first).brand(:visa, :mastercard).must_be_nil
+      expect(detector(value.first).brand(:visa, :mastercard)).must_be_nil
     end
   end
 
@@ -133,7 +133,7 @@ describe CreditCardValidations do
 
           it 'should not validate number as voyager' do
             expect(detector(voyager_number).respond_to?(:voyager?)).must_equal false
-            detector(voyager_number).brand.must_be_nil
+            expect(detector(voyager_number).brand).must_be_nil
           end
         end
       end
@@ -142,7 +142,7 @@ describe CreditCardValidations do
     describe 'plugins' do
       [:diners_us, :en_route, :laser].each do |brand|
         it "should support #{brand}" do
-          -> { CreditCardValidations::Factory.random(brand) }.
+          expect(-> { CreditCardValidations::Factory.random(brand) }).
             must_raise(CreditCardValidations::Error)
           custom_number = 'some_number'
           expect(detector(custom_number).respond_to?("#{brand}?")).must_equal false
@@ -155,7 +155,7 @@ describe CreditCardValidations do
     end
 
     it 'should raise Error if no brand added before' do
-      -> { CreditCardValidations::Detector::add_rule(:undefined_brand, 20, [20]) }.
+      expect(-> { CreditCardValidations::Detector::add_rule(:undefined_brand, 20, [20]) }).
         must_raise(CreditCardValidations::Error)
     end
   end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -4,14 +4,14 @@ describe CreditCardValidations::Factory do
 
   it 'should generate random brand' do
     number = CreditCardValidations::Factory.random
-    CreditCardValidations::Detector.new(number).valid?.must_equal true
+    expect(CreditCardValidations::Detector.new(number).valid?).must_equal true
   end
 
   CreditCardValidations::Detector.brands.keys.sort.each do |key|
     describe "#{key}" do
       it "should generate valid #{key}" do
         number = CreditCardValidations::Factory.random(key)
-        CreditCardValidations::Detector.new(number).valid?(key).must_equal true
+        expect(CreditCardValidations::Detector.new(number).valid?(key)).must_equal true
       end
     end
   end

--- a/spec/string_spec.rb
+++ b/spec/string_spec.rb
@@ -23,8 +23,8 @@ describe 'String ext' do
   end
 
   it 'should not allow detect brand for invalid card' do
-    invalid.credit_card_brand.must_be_nil
-    invalid.credit_card_brand_name.must_be_nil
+    expect(invalid.credit_card_brand).must_be_nil
+    expect(invalid.credit_card_brand_name).must_be_nil
     expect(invalid.valid_credit_card_brand?(:mastercard)).must_equal false
     expect(invalid.valid_credit_card_brand?(:visa, :amex)).must_equal false
   end

--- a/spec/string_spec.rb
+++ b/spec/string_spec.rb
@@ -8,25 +8,25 @@ describe 'String ext' do
   let(:invalid) { INVALID_NUMBERS.sample }
 
   it 'should allow detect brand for mastercard' do
-    mastercard.credit_card_brand.must_equal :mastercard
-    mastercard.credit_card_brand_name.must_equal 'MasterCard'
-    mastercard.valid_credit_card_brand?(:mastercard).must_equal true
-    mastercard.valid_credit_card_brand?('MasterCard').must_equal true
-    mastercard.valid_credit_card_brand?(:visa, :amex).must_equal false
+    expect(mastercard.credit_card_brand).must_equal :mastercard
+    expect(mastercard.credit_card_brand_name).must_equal 'MasterCard'
+    expect(mastercard.valid_credit_card_brand?(:mastercard)).must_equal true
+    expect(mastercard.valid_credit_card_brand?('MasterCard')).must_equal true
+    expect(mastercard.valid_credit_card_brand?(:visa, :amex)).must_equal false
   end
 
   it 'should allow detect brand for visa' do
-    visa.credit_card_brand.must_equal :visa
-    visa.credit_card_brand_name.must_equal 'Visa'
-    visa.valid_credit_card_brand?(:mastercard).must_equal false
-    visa.valid_credit_card_brand?(:visa, :amex).must_equal true
+    expect(visa.credit_card_brand).must_equal :visa
+    expect(visa.credit_card_brand_name).must_equal 'Visa'
+    expect(visa.valid_credit_card_brand?(:mastercard)).must_equal false
+    expect(visa.valid_credit_card_brand?(:visa, :amex)).must_equal true
   end
 
   it 'should not allow detect brand for invalid card' do
     invalid.credit_card_brand.must_be_nil
     invalid.credit_card_brand_name.must_be_nil
-    invalid.valid_credit_card_brand?(:mastercard).must_equal false
-    invalid.valid_credit_card_brand?(:visa, :amex).must_equal false
+    expect(invalid.valid_credit_card_brand?(:mastercard)).must_equal false
+    expect(invalid.valid_credit_card_brand?(:visa, :amex)).must_equal false
   end
 
 end


### PR DESCRIPTION
minitest warns about current specs since https://github.com/seattlerb/minitest/commit/e6bc4485730403faff6966c1671cf5de72b2d233
So updated the specs with newstyle and specify to use latest minitest in all environment.

But latest minitest requires ruby 2.2 or later https://github.com/seattlerb/minitest/blob/13c48a03d84a2a87855a4de0c959f96800100357/Rakefile#L14

So I allow failures ruby 2.1.10 in CI