### PR TITLE
Use supported action ruby/setup-ruby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,11 @@ jobs:
     env:
       RAILS_VERSION: ${{ matrix.rails }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
     - name: Run tests
       run: |
-        gem install bundler -v '< 2'
-        bundle install
         bundle exec rake


### PR DESCRIPTION
Use [ruby/setup](https://github.com/ruby/setup-ruby)-ruby which is the replacement for retired [actions/setup-ruby](https://github.com/actions/setup-ruby)

Enable bundle caching.