### PR TITLE
Allow to use Rails over v7.1.1

### DIFF
--- a/credit_card_validations.gemspec
+++ b/credit_card_validations.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
 
-  gem.add_dependency "activemodel", ">= 5.2", "<= 7.1"
-  gem.add_dependency "activesupport", ">= 5.2", "<= 7.1"
+  gem.add_dependency "activemodel", ">= 5.2", "< 7.2"
+  gem.add_dependency "activesupport", ">= 5.2", "< 7.2"
 
 
   gem.add_development_dependency "minitest", '~> 5.14.3'


### PR DESCRIPTION
The current version specification only allows to use `7.1.0`. This PR fixes to allow to use of the higher versions.