### PR TITLE
New match brand logic.

### DIFF
--- a/lib/credit_card_validations/detector.rb
+++ b/lib/credit_card_validations/detector.rb
@@ -28,8 +28,14 @@ module CreditCardValidations
     def valid_number?(*keys)
       selected_brands = keys.blank? ? self.brands : resolve_keys(*keys)
       if selected_brands.any?
+        matched_brands = []
         selected_brands.each do |key, brand|
-          return key if matches_brand?(brand)
+          match_data = matches_brand?(brand)
+          matched_brands << {brand: key, matched_prefix_length: match_data.to_s.length} if match_data
+        end
+
+        if matched_brands.present?
+          return matched_brands.sort{|a, b| a[:matched_prefix_length] <=> b[:matched_prefix_length]}.last[:brand]
         end
       end
       nil
@@ -64,8 +70,8 @@ module CreditCardValidations
       rules.each do |rule|
         if (options[:skip_luhn] || valid_luhn?) &&
             rule[:length].include?(number.length) &&
-            number.match(rule[:regexp])
-          return true
+            match_data = number.match(rule[:regexp])
+          return match_data
         end
       end
       false

--- a/lib/credit_card_validations/version.rb
+++ b/lib/credit_card_validations/version.rb
@@ -1,3 +1,3 @@
 module CreditCardValidations
-  VERSION = '6.1.0'
+  VERSION = '6.2.0'
 end

--- a/spec/credit_card_validations_spec.rb
+++ b/spec/credit_card_validations_spec.rb
@@ -170,6 +170,28 @@ describe CreditCardValidations do
           end
         end
       end
+
+      describe 'Add kortimilli rule' do
+        let(:kortimilli_number) { '505827028341713' }
+
+        it 'before invoke add_brand credit card behaves like maestro' do
+          expect(detector(kortimilli_number).valid?(:maestro)).must_equal true
+          expect(detector(kortimilli_number).maestro?).must_equal true
+          expect(detector(kortimilli_number).brand).must_equal :maestro
+        end
+
+        describe 'after adding wider prefix for kortimilli' do
+          before do
+            CreditCardValidations::Detector.add_brand(:kortimilli, length: 15, prefixes: '505827028')
+          end
+
+          it 'should validate number as kortimilli' do
+            expect(detector(kortimilli_number).valid?(:kortimilli)).must_equal true
+            expect(detector(kortimilli_number).kortimilli?).must_equal true
+            expect(detector(kortimilli_number).brand).must_equal :kortimilli
+          end
+        end
+      end
     end
 
     describe 'plugins' do


### PR DESCRIPTION
Вітаю!

Problem: 

After adding new brand which intersects with existed brand prefix but with more accurate prefix, detector still return old brand value.

Example:

We have brand maestro with prefix 505. We add new brand kortimilli with more accurate prefix 505827028. 
`CreditCardValidations::Detector.add_brand(:kortimilli, length: 15, prefixes: '505827028')`

But detector still return maestro instead kortimilli
`CreditCardValidations::Detector.new('505827028341713').brand # => :maestro`

Solution:
Instead of returning first matched by prefix brand, we get all matched and return one with more accurate prefix length.