### PR TITLE
Allow running against Rails edge

### DIFF
--- a/credit_card_validations.gemspec
+++ b/credit_card_validations.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
 
-  gem.add_dependency 'activemodel', '>= 5.2', '< 8.2'
-  gem.add_dependency 'activesupport', '>= 5.2', '< 8.2'
+  gem.add_dependency 'activemodel', '>= 5.2'
+  gem.add_dependency 'activesupport', '>= 5.2'
 
 
   gem.add_development_dependency 'minitest'


### PR DESCRIPTION
We're trying to test our app on Rails edge, as to find incompatiblities and bugs sooner, but this gem prevent us from doing so.

There's no reason to believe any specific version of Rails will break the gem, the last few times the version requirement was bumped without any additional changes.

Hence it's likely better to let users test and report issues.