### PR TITLE
Make Luhn strict; move PAN sanitization into Detector

### DIFF
--- a/lib/credit_card_validations/detector.rb
+++ b/lib/credit_card_validations/detector.rb
@@ -12,7 +12,7 @@ module CreditCardValidations
     attr_reader :number
 
     def initialize(number)
-      @number = number.to_s.tr('- ', '')
+      @number = number.to_s.gsub(/[\s\-]/, '')
     end
 
     # credit card number validation

--- a/lib/credit_card_validations/luhn.rb
+++ b/lib/credit_card_validations/luhn.rb
@@ -1,15 +1,22 @@
 # == CreditCardValidations Luhn
-# simple class to validate Luhn numbers.
+# Strict Luhn validator — accepts digit-only strings.
 #
-#   Luhn.valid? 4111111111111111
+#   Luhn.valid?('4111111111111111')   # => true
+#   Luhn.valid?('4111 1111 1111 1111') # => false (caller must strip formatting)
+#   Luhn.valid?('')                    # => false
+#   Luhn.valid?(nil)                   # => false
+#
+# Call sites that handle user input should strip formatting first; the
+# bundled Detector does this before delegating here.
 #
 module CreditCardValidations
   class Luhn
     def self.valid?(number)
-      s1 = s2 = 0
-      number.to_s.reverse.chars.each_slice(2) do |odd, even|
-        s1 += odd.to_i
+      return false if number.nil? || !number.match?(/\A\d+\z/)
 
+      s1 = s2 = 0
+      number.reverse.chars.each_slice(2) do |odd, even|
+        s1 += odd.to_i
         double = even.to_i * 2
         double -= 9 if double >= 10
         s2 += double
@@ -17,6 +24,4 @@ module CreditCardValidations
       (s1 + s2) % 10 == 0
     end
   end
-end  
-  
-  
+end

--- a/spec/credit_card_validations_spec.rb
+++ b/spec/credit_card_validations_spec.rb
@@ -66,6 +66,39 @@ describe CreditCardValidations do
       expect(card_detector.valid?(:unionpay)).must_equal true
     end
 
+    describe 'strict input contract' do
+      let(:valid_pan) { VALID_NUMBERS[:visa].first.tr(' -', '') }
+
+      it 'rejects formatted PAN (caller must strip)' do
+        expect(CreditCardValidations::Luhn.valid?("4111 1111 1111 1111")).must_equal false
+        expect(CreditCardValidations::Luhn.valid?("4111-1111-1111-1111")).must_equal false
+        expect(CreditCardValidations::Luhn.valid?("#{valid_pan}\n")).must_equal false
+      end
+
+      it 'rejects non-digit garbage' do
+        expect(CreditCardValidations::Luhn.valid?("4111abcd11111111")).must_equal false
+      end
+
+      it 'rejects nil and empty string' do
+        expect(CreditCardValidations::Luhn.valid?(nil)).must_equal false
+        expect(CreditCardValidations::Luhn.valid?('')).must_equal false
+      end
+
+      it 'accepts a clean digit string' do
+        expect(CreditCardValidations::Luhn.valid?(valid_pan)).must_equal true
+      end
+    end
+
+    describe 'Detector strips formatting before delegating' do
+      it 'accepts spaces, dashes, and whitespace in Detector input' do
+        formatted  = '4111 1111 1111 1111'
+        with_dashes = '4111-1111-1111-1111'
+        from_csv    = "4111111111111111\n"
+        expect(CreditCardValidations::Detector.new(formatted).valid?).must_equal true
+        expect(CreditCardValidations::Detector.new(with_dashes).valid?).must_equal true
+        expect(CreditCardValidations::Detector.new(from_csv).valid?).must_equal true
+      end
+    end
   end
 
 


### PR DESCRIPTION
## Summary

\`Luhn.valid?\` previously returned \`true\` for \`nil\`, empty string, and any non-digit input due to the vacuous-truth bug: each non-digit char parsed to \`0\`, the sum stayed divisible by 10.

After this PR:

- \`Luhn.valid?\` rejects \`nil\`, empty string, and any string containing non-digit characters.
- \`Detector#initialize\` now strips all whitespace (spaces, tabs, newlines, CR) and dashes in the constructor before delegating to Luhn. The user-facing API stays permissive: \`Detector.new("4111 1111 1111 1111\\n").valid?\` still works.

Separation of concerns: \`Luhn\` is pure math on clean digits; \`Detector\` is the boundary that handles dirty input. This matches the ActiveMerchant pattern.

## Test plan

- [x] New strict-contract spec: rejects formatted PAN, non-digits, nil, empty
- [x] New Detector-stripping spec: accepts spaces, dashes, CSV newlines
- [x] Full suite passes: 64 runs, 0 failures