### PR TITLE
Use YAML.safe_load_file for brand source

### DIFF
--- a/lib/credit_card_validations.rb
+++ b/lib/credit_card_validations.rb
@@ -39,7 +39,7 @@ module CreditCardValidations
   end
 
   def self.data
-    YAML.load_file(source) || {}
+    YAML.safe_load_file(source, permitted_classes: [Symbol]) || {}
   end
 
   def self.reload!

--- a/spec/credit_card_validations_spec.rb
+++ b/spec/credit_card_validations_spec.rb
@@ -40,6 +40,22 @@ describe CreditCardValidations do
 
   end
 
+  describe 'safe YAML loading' do
+    it 'rejects a brand source containing arbitrary Ruby objects' do
+      require 'tempfile'
+      Tempfile.create(['unsafe', '.yaml']) do |f|
+        f.write("--- !ruby/object:Object {}\n")
+        f.flush
+        expect(-> {
+          CreditCardValidations.configure { |c| c.source = f.path }
+        }).must_raise Psych::DisallowedClass
+      end
+    ensure
+      CreditCardValidations.reset
+      CreditCardValidations.reload!
+    end
+  end
+
   describe 'MMI' do
     it 'should detect issuer category' do
       d = detector(VALID_NUMBERS[:visa].first)


### PR DESCRIPTION
## Summary

\`YAML.load_file\` swapped to \`YAML.safe_load_file(source, permitted_classes: [Symbol])\`.

On supported Ruby versions (3.1+ with Psych 5) the default \`YAML.load_file\` is already safe — this PR makes the contract explicit:

- Documents the intent in code: any reader sees \`safe_load_file\` and knows arbitrary Ruby object deserialization is rejected.
- Stricter allow-list — only \`Symbol\` is permitted on top of the standard scalar/collection types. If the brand format ever needs another class, it must be added explicitly.
- Future-proof against any future Psych default reverts.

## Threat model

The gem exposes \`CreditCardValidations.configure { |c| c.source = path }\`. If an application ever passes a path influenced by an attacker (uploaded file, env var, shared config), \`load_file\` historically allowed \`!ruby/object:...\` payloads that triggered arbitrary Ruby instantiation. \`safe_load_file\` blocks that vector outright.

## Test plan

- [x] New spec: rejects \`!ruby/object:Object {}\` brand source with \`Psych::DisallowedClass\`
- [x] Full suite passes: 60 runs, 0 failures