### PR TITLE
Add Detector PAN display helpers

### DIFF
--- a/lib/credit_card_validations/detector.rb
+++ b/lib/credit_card_validations/detector.rb
@@ -50,7 +50,53 @@ module CreditCardValidations
       self.class.brand_name(brand)
     end
 
+    # Last four digits of the PAN, or nil if the PAN has fewer than 4 digits.
+    def last4
+      number.length >= 4 ? number[-4, 4] : nil
+    end
+
+    # PAN with every digit but the last 4 replaced by mask_char.
+    # Returns the original number when shorter than 4 digits — never raises.
+    def masked(mask_char = '*')
+      return number if number.length < 4
+      mask_char.to_s[0] * (number.length - 4) + last4.to_s
+    end
+
+    # All brands whose prefixes can still match the (possibly partial) PAN.
+    # Length and Luhn are not checked — useful for live UX before the user
+    # finishes typing.
+    def possible_brands
+      return [] if number.empty?
+      self.class.brands.each_with_object([]) do |(key, brand), acc|
+        next unless brand.fetch(:rules).any? do |rule|
+          rule[:prefixes].any? do |prefix|
+            n = [number.length, prefix.length].min
+            number[0, n] == prefix[0, n]
+          end
+        end
+        acc << key
+      end
+    end
+
+    # Human-readable PAN grouped per network convention. Falls back to the
+    # first possible brand while the user is still typing.
+    def formatted(separator = ' ')
+      groups_for(brand || possible_brands.first).each_with_object([]) do |size, acc|
+        slice = number[acc.join.length, size]
+        acc << slice if slice && !slice.empty?
+      end.join(separator)
+    end
+
     protected
+
+    def groups_for(detected_brand)
+      segments = self.class.brands.dig(detected_brand, :options, :segments)
+      return segments if segments
+      groups = Array.new(number.length / 4, 4)
+      remainder = number.length % 4
+      groups << remainder if remainder.positive?
+      groups
+    end
 
     def resolve_keys(*keys)
       brand_keys = keys.map do |el|

--- a/lib/data/brands.yaml
+++ b/lib/data/brands.yaml
@@ -53,6 +53,10 @@
     - '37'
   :options:
     :brand_name: American Express
+    :segments:
+    - 4
+    - 6
+    - 5
 :diners:
   :rules:
   - :length:
@@ -68,6 +72,10 @@
     - '38'
   :options:
     :brand_name: Diners Club
+    :segments:
+    - 4
+    - 6
+    - 5
 :jcb:
   :rules:
   - :length:

--- a/spec/credit_card_validations_spec.rb
+++ b/spec/credit_card_validations_spec.rb
@@ -105,6 +105,98 @@ describe CreditCardValidations do
     expect(detector(visa).valid?('American Express')).must_equal false
   end
 
+  describe 'PAN display helpers' do
+    let(:visa) { detector('4111 1111 1111 1111') }
+    let(:amex) { detector('3782 822463 10005') }
+
+    describe '#last4' do
+      it 'returns the last four digits of the PAN' do
+        expect(visa.last4).must_equal '1111'
+        expect(amex.last4).must_equal '0005'
+      end
+
+      it 'returns nil for a PAN shorter than 4 digits' do
+        expect(detector('12').last4).must_be_nil
+        expect(detector('').last4).must_be_nil
+      end
+    end
+
+    describe '#masked' do
+      it 'replaces every digit except the last 4 with the mask char' do
+        expect(visa.masked).must_equal '************1111'
+        expect(amex.masked).must_equal '***********0005'
+      end
+
+      it 'accepts a custom mask char' do
+        expect(visa.masked('#')).must_equal '############1111'
+      end
+
+      it 'does not raise and returns the input when PAN is shorter than 4' do
+        expect(detector('12').masked).must_equal '12'
+        expect(detector('').masked).must_equal ''
+      end
+    end
+
+    describe '#formatted' do
+      it 'groups by 4 for non-amex brands' do
+        expect(visa.formatted).must_equal '4111 1111 1111 1111'
+      end
+
+      it 'groups 4-6-5 for amex' do
+        expect(amex.formatted).must_equal '3782 822463 10005'
+      end
+
+      it 'uses possible_brands fallback for partial amex input' do
+        # length 10, not yet a full 15-digit amex; brand returns nil but
+        # possible_brands knows the leading "37" can become amex
+        partial_amex = detector('3782822463')
+        expect(partial_amex.brand).must_be_nil
+        expect(partial_amex.formatted).must_equal '3782 822463'
+      end
+
+      it 'falls back to default 4-by-4 grouping when brand has no :segments option' do
+        # simulates a user-supplied YAML that predates the :segments option:
+        # the brand is registered without it, so #formatted must not crash
+        # and must apply the default grouping.
+        CreditCardValidations::Detector.add_brand(:my_brand, length: 16, prefixes: '8000')
+        sample = CreditCardValidations::Factory.random(:my_brand)
+        expect(detector(sample).brand).must_equal :my_brand
+        expect(detector(sample).formatted).must_equal sample.scan(/.{4}/).join(' ')
+      ensure
+        CreditCardValidations::Detector.delete_brand(:my_brand)
+      end
+
+      it 'accepts a custom separator' do
+        expect(visa.formatted('-')).must_equal '4111-1111-1111-1111'
+      end
+    end
+
+    describe '#possible_brands' do
+      it 'returns brands whose prefix matches the partial PAN' do
+        expect(detector('4').possible_brands).must_include :visa
+        expect(detector('37').possible_brands).must_include :amex
+      end
+
+      it 'returns all brands sharing the partial prefix' do
+        # leading "5" is ambiguous across mastercard, maestro, elo, dankort
+        expect(detector('5').possible_brands.sort).must_equal %i[dankort elo maestro mastercard]
+      end
+
+      it 'narrows as more digits arrive' do
+        expect(detector('2').possible_brands.sort).must_equal %i[jcb mastercard mir]
+        expect(detector('2199').possible_brands).must_equal []
+      end
+
+      it 'returns [] for empty input' do
+        expect(detector('').possible_brands).must_equal []
+      end
+
+      it 'returns [] for a prefix not matching any brand' do
+        expect(detector('9999').possible_brands).must_equal []
+      end
+    end
+  end
+
   it 'should support multiple brands for single check' do
     VALID_NUMBERS.slice(:visa, :mastercard).each do |key, value|
       expect(detector(value.first).brand(:visa, :mastercard)).must_equal key


### PR DESCRIPTION
## Summary

Adds four new methods on \`Detector\` aimed at UI presentation of the PAN.

### \`#last4\`
Returns the last four digits, or \`nil\` if the PAN is shorter than 4 chars.

### \`#masked(mask_char = '*')\`
Replaces every digit but the last 4 with \`mask_char\`. Returns the original number untouched when PAN is shorter than 4, so it never raises \`ArgumentError: negative argument\` on short input (closes the existing crash for inputs like \`Detector.new('12').masked\`).

### \`#formatted(separator = ' ')\`
Groups the PAN per brand convention:

- Visa/MC/Discover/JCB (16): \`4111 1111 1111 1111\`
- Amex (15): \`3782 822463 10005\`
- Diners (14): \`3056 930902 5904\`

When the user is mid-typing (\`#brand\` returns \`nil\`), \`#formatted\` falls back to \`#possible_brands.first\` so an Amex still groups 4-6-5 from the moment the leading \`37\` is recognizable.

Brand-specific segment lengths live in \`brands.yaml\` under \`:options.:segments\`. No \`Detector\`-side hardcoded table.

### \`#possible_brands\`
Returns brand keys whose prefix can still match the (possibly partial) PAN. Length and Luhn are not checked — useful for typeahead/live UX.
