### PR TITLE
Add Detector#valid_cvv?

### DIFF
--- a/lib/credit_card_validations/detector.rb
+++ b/lib/credit_card_validations/detector.rb
@@ -87,6 +87,19 @@ module CreditCardValidations
       end.join(separator)
     end
 
+    # Validates the card verification value (CVV / CVC / CID) against the
+    # detected brand's declared code size. Each brand must declare
+    # :code:{:name, :size} under :options. Raises when a detected brand
+    # has no :code (misconfigured registry). Returns false when the brand
+    # cannot be determined or when the input has the wrong shape.
+    def valid_cvv?(code)
+      return false if code.nil? || !code.to_s.match?(/\A\d+\z/)
+      return false if brand.nil?
+      spec = self.class.brands.dig(brand, :options, :code)
+      raise Error, "brand #{brand.inspect} has no :code option" if spec.nil?
+      code.to_s.length == spec[:size]
+    end
+
     protected
 
     def groups_for(detected_brand)

--- a/lib/data/brands.yaml
+++ b/lib/data/brands.yaml
@@ -9,6 +9,9 @@
     - '4'
   :options:
     :brand_name: Visa
+    :code:
+      :name: CVV
+      :size: 3
 :mastercard:
   :rules:
   - :length:
@@ -44,6 +47,9 @@
     - '55'
   :options:
     :brand_name: MasterCard
+    :code:
+      :name: CVC
+      :size: 3
 :amex:
   :rules:
   - :length:
@@ -57,6 +63,9 @@
     - 4
     - 6
     - 5
+    :code:
+      :name: CID
+      :size: 4
 :diners:
   :rules:
   - :length:
@@ -76,6 +85,9 @@
     - 4
     - 6
     - 5
+    :code:
+      :name: CVV
+      :size: 3
 :jcb:
   :rules:
   - :length:
@@ -101,6 +113,9 @@
     - '357266'
   :options:
     :brand_name: JCB
+    :code:
+      :name: CVV
+      :size: 3
 :solo:
   :rules:
   - :length:
@@ -110,6 +125,10 @@
     :prefixes:
     - '6334'
     - '6767'
+  :options:
+    :code:
+      :name: CVV
+      :size: 3
 :switch:
   :rules:
   - :length:
@@ -123,6 +142,10 @@
     - '633303'
     - '633301'
     - '633300'
+  :options:
+    :code:
+      :name: CVV
+      :size: 3
 :maestro:
   :rules:
   - :length:
@@ -228,6 +251,10 @@
     - '6769'
     - '6771'
     - '679'
+  :options:
+    :code:
+      :name: CVC
+      :size: 3
 :unionpay:
   :rules:
   - :length:
@@ -293,12 +320,19 @@
   :options:
     :skip_luhn: true
     :brand_name: China UnionPay
+    :code:
+      :name: CVN
+      :size: 3
 :dankort:
   :rules:
   - :length:
     - 16
     :prefixes:
     - '5019'
+  :options:
+    :code:
+      :name: CVV
+      :size: 3
 :rupay:
   :rules:
   - :length:
@@ -341,6 +375,9 @@
     - '8202'
   :options:
     :skip_luhn: true
+    :code:
+      :name: CVV
+      :size: 3
 :hipercard:
   :rules:
   - :length:
@@ -353,6 +390,10 @@
     - '637599'
     - '637609'
     - '637612'
+  :options:
+    :code:
+      :name: CVC
+      :size: 3
 :elo:
   :rules:
   - :length:
@@ -499,6 +540,9 @@
   :options:
     :skip_luhn: true
     :brand_name: Elo
+    :code:
+      :name: CVE
+      :size: 3
 :mir:
   :rules:
   - :length:
@@ -509,6 +553,10 @@
     - '2202'
     - '2203'
     - '2204'
+  :options:
+    :code:
+      :name: CVP2
+      :size: 3
 :discover:
   :rules:
   - :length:
@@ -535,3 +583,6 @@
     - '65'
   :options:
     :brand_name: Discover
+    :code:
+      :name: CID
+      :size: 3

--- a/spec/credit_card_validations_spec.rb
+++ b/spec/credit_card_validations_spec.rb
@@ -246,6 +246,58 @@ describe CreditCardValidations do
     end
   end
 
+  describe '#valid_cvv?' do
+    it 'requires 4 digits for amex' do
+      d = detector(VALID_NUMBERS[:amex].first)
+      expect(d.valid_cvv?('1234')).must_equal true
+      expect(d.valid_cvv?('123')).must_equal false
+    end
+
+    it 'requires 3 digits for visa and mastercard' do
+      [VALID_NUMBERS[:visa].first, VALID_NUMBERS[:mastercard].first].each do |pan|
+        d = detector(pan)
+        expect(d.valid_cvv?('123')).must_equal true
+        expect(d.valid_cvv?('1234')).must_equal false
+      end
+    end
+
+    it 'rejects non-digit input' do
+      d = detector(VALID_NUMBERS[:visa].first)
+      expect(d.valid_cvv?('12a')).must_equal false
+      expect(d.valid_cvv?(nil)).must_equal false
+      expect(d.valid_cvv?('')).must_equal false
+    end
+
+    it 'returns false when brand is unknown' do
+      d = detector('9999999999999999')
+      expect(d.brand).must_be_nil
+      expect(d.valid_cvv?('123')).must_equal false
+      expect(d.valid_cvv?('1234')).must_equal false
+    end
+
+    it 'raises when detected brand has no :code option configured' do
+      CreditCardValidations::Detector.add_brand(:misconfigured, length: 16, prefixes: '8001')
+      sample = CreditCardValidations::Factory.random(:misconfigured)
+      expect(-> { detector(sample).valid_cvv?('123') }).must_raise CreditCardValidations::Error
+    ensure
+      CreditCardValidations::Detector.delete_brand(:misconfigured)
+    end
+
+    it 'uses :code option from brands.yaml when present' do
+      CreditCardValidations::Detector.add_brand(
+        :custom_5digit_cvv, { length: 16, prefixes: '8000' },
+        code: { name: 'CSC', size: 5 }
+      )
+      sample = CreditCardValidations::Factory.random(:custom_5digit_cvv)
+      d = detector(sample)
+      expect(d.brand).must_equal :custom_5digit_cvv
+      expect(d.valid_cvv?('12345')).must_equal true
+      expect(d.valid_cvv?('1234')).must_equal false
+    ensure
+      CreditCardValidations::Detector.delete_brand(:custom_5digit_cvv)
+    end
+  end
+
   it 'should support multiple brands for single check' do
     VALID_NUMBERS.slice(:visa, :mastercard).each do |key, value|
       expect(detector(value.first).brand(:visa, :mastercard)).must_equal key


### PR DESCRIPTION
## Summary

Adds \`Detector#valid_cvv?(code)\` — validates a card verification value against the detected brand's expected code size.

\`\`\`ruby
d = CreditCardValidations::Detector.new(amex_pan)
d.valid_cvv?('1234')  # => true
d.valid_cvv?('123')   # => false (Amex expects 4)
\`\`\`

### Strict configuration contract

Every brand in \`brands.yaml\` now declares \`:code:\` under \`:options:\`:

\`\`\`yaml
:amex:
  :options:
    :brand_name: American Express
    :code: { :name: CID, :size: 4 }
:visa:
  :options:
    :brand_name: Visa
    :code: { :name: CVV, :size: 3 }
\`\`\`



This forces explicit declaration of CVV semantics per brand and makes runtime-added brands (\`Detector.add_brand(:my_brand, ..., code: { name: 'CSC', size: 5 })\`) first-class.
