### PR TITLE
Add ActiveModel CVV/Expiration validators and Card composite model

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,66 @@ for all known brands
 validates :number, presence: true, credit_card_number: true
 ```
 
+### CVV and Expiration validators
+
+CVV against a brand pulled from another attribute:
+
+```ruby
+class Payment
+  include ActiveModel::Validations
+  attr_accessor :card_number, :cvv
+
+  validates :card_number, credit_card_number: true
+  validates :cvv,         credit_card_cvv: { brand_from: :card_number }
+end
+```
+
+CVV against a literal brand:
+
+```ruby
+validates :cvv, credit_card_cvv: { brand: :amex }
+```
+
+Expiration held in a single string attribute (`MM/YY`, `MM/YYYY`, `MMYY`, ...):
+
+```ruby
+validates :expiration, credit_card_expiration: true
+```
+
+When the form uses two separate fields (month and year dropdowns), use the
+`Expiration` class directly in a `validate` block:
+
+```ruby
+class Payment
+  attr_accessor :exp_month, :exp_year
+
+  validate do
+    exp = CreditCardValidations::Expiration.new(exp_month, exp_year)
+    errors.add(:exp_month, :invalid) unless exp.valid?
+  end
+end
+```
+
+### CreditCardValidations::Card
+
+A composite model wrapping `Detector` and `Expiration` behind a single
+ActiveModel-aware object:
+
+```ruby
+card = CreditCardValidations::Card.new(
+  number: '4111 1111 1111 1111',
+  month: 12, year: 2027,
+  verification_value: '123',
+  name: 'John Smith'
+)
+card.valid?            # => true
+card.brand             # => :visa
+card.display_number    # => "************1111"
+card.last_digits       # => "1111"
+card.expired?          # => false
+card.formatted_number  # => "4111 1111 1111 1111"
+```
+
 ### Examples using CreditCardValidations::Detector class
 
 ```ruby

--- a/lib/active_model/credit_card_cvv_validator.rb
+++ b/lib/active_model/credit_card_cvv_validator.rb
@@ -1,0 +1,35 @@
+# == ActiveModel CreditCardCvvValidator
+#
+# Validates a card verification value (CVV / CVC / CID) against either a
+# brand passed explicitly, or a brand derived from another attribute.
+#
+#   class Payment
+#     include ActiveModel::Validations
+#     attr_accessor :card_number, :cvv
+#
+#     validates :cvv, credit_card_cvv: { brand_from: :card_number }
+#   end
+#
+#   class Payment
+#     validates :cvv, credit_card_cvv: { brand: :amex }
+#   end
+#
+module ActiveModel
+  module Validations
+    class CreditCardCvvValidator < EachValidator
+      def validate_each(record, attribute, value)
+        brand = resolve_brand(record)
+        return if brand && CreditCardValidations::Detector.valid_cvv?(value, brand)
+        record.errors.add(attribute, options[:message] || :invalid)
+      end
+
+      private
+
+      def resolve_brand(record)
+        return options[:brand] if options[:brand]
+        pan = record.public_send(options[:brand_from]).to_s if options[:brand_from]
+        CreditCardValidations::Detector.new(pan).brand if pan
+      end
+    end
+  end
+end

--- a/lib/active_model/credit_card_expiration_validator.rb
+++ b/lib/active_model/credit_card_expiration_validator.rb
@@ -1,0 +1,26 @@
+# == ActiveModel CreditCardExpirationValidator
+#
+# Validates a card expiration date held in a single attribute as a parseable
+# string (MM/YY, MM/YYYY, MMYY, ...).
+#
+#   class Payment
+#     include ActiveModel::Validations
+#     attr_accessor :expiration
+#
+#     validates :expiration, credit_card_expiration: true
+#   end
+#
+# For forms with separate month + year fields, use the Expiration class
+# directly in a plain validate block (see README).
+#
+module ActiveModel
+  module Validations
+    class CreditCardExpirationValidator < EachValidator
+      def validate_each(record, attribute, value)
+        expiration = CreditCardValidations::Expiration.parse(value)
+        return if expiration && expiration.valid?
+        record.errors.add(attribute, options[:message] || :invalid)
+      end
+    end
+  end
+end

--- a/lib/credit_card_validations.rb
+++ b/lib/credit_card_validations.rb
@@ -5,6 +5,8 @@ require 'active_model'
 require 'active_support/core_ext'
 require 'active_model/validations'
 require 'active_model/credit_card_number_validator'
+require 'active_model/credit_card_cvv_validator'
+require 'active_model/credit_card_expiration_validator'
 require 'yaml'
 
 module CreditCardValidations
@@ -15,6 +17,7 @@ module CreditCardValidations
   autoload :Factory, 'credit_card_validations/factory'
   autoload :Mmi, 'credit_card_validations/mmi'
   autoload :Expiration, 'credit_card_validations/expiration'
+  autoload :Card, 'credit_card_validations/card'
 
   attr_accessor :configuration
 

--- a/lib/credit_card_validations/card.rb
+++ b/lib/credit_card_validations/card.rb
@@ -1,0 +1,61 @@
+require 'active_model'
+
+# == CreditCardValidations::Card
+#
+# Slim alternative to ActiveMerchant::Billing::CreditCard for the validation
+# use case. Wraps PAN, expiration, verification value and cardholder name
+# behind a single ActiveModel-aware object.
+#
+#   card = CreditCardValidations::Card.new(
+#     number: '4111 1111 1111 1111',
+#     month: 12, year: 2027,
+#     verification_value: '123',
+#     name: 'John Smith'
+#   )
+#   card.valid?            # => true
+#   card.brand             # => :visa
+#   card.display_number    # => "************1111"
+#   card.last_digits       # => "1111"
+#   card.expired?          # => false
+#   card.formatted_number  # => "4111 1111 1111 1111"
+#
+module CreditCardValidations
+  class Card
+    include ActiveModel::Model
+
+    attr_accessor :number, :month, :year, :verification_value, :name
+
+    validates :number, credit_card_number: true
+    validates :verification_value, credit_card_cvv: { brand_from: :number }
+    validate :expiration_must_be_valid
+
+    def brand              = detector.brand
+    def brand_name         = detector.brand_name
+    def last_digits        = detector.last4
+    def display_number     = detector.masked
+    def formatted_number   = detector.formatted
+
+    def expiration
+      return nil unless month && year
+      Expiration.new(month, year)
+    end
+
+    def expired?
+      exp = expiration
+      exp.nil? || exp.expired?
+    end
+
+    def detector
+      @detector ||= Detector.new(number)
+    end
+
+    private
+
+    def expiration_must_be_valid
+      return if month.blank? && year.blank?
+      exp = expiration
+      errors.add(:base, :expired) if exp && exp.expired?
+      errors.add(:month, :invalid) if exp && !(1..12).cover?(exp.month)
+    end
+  end
+end

--- a/lib/credit_card_validations/detector.rb
+++ b/lib/credit_card_validations/detector.rb
@@ -87,17 +87,12 @@ module CreditCardValidations
       end.join(separator)
     end
 
-    # Validates the card verification value (CVV / CVC / CID) against the
-    # detected brand's declared code size. Each brand must declare
-    # :code:{:name, :size} under :options. Raises when a detected brand
-    # has no :code (misconfigured registry). Returns false when the brand
-    # cannot be determined or when the input has the wrong shape.
+    # Validates the card verification value against the detected brand's
+    # declared :code size. Returns false when the brand cannot be determined
+    # from the PAN or the input has the wrong shape. Raises when a detected
+    # brand is missing :code in the registry.
     def valid_cvv?(code)
-      return false if code.nil? || !code.to_s.match?(/\A\d+\z/)
-      return false if brand.nil?
-      spec = self.class.brands.dig(brand, :options, :code)
-      raise Error, "brand #{brand.inspect} has no :code option" if spec.nil?
-      code.to_s.length == spec[:size]
+      self.class.valid_cvv?(code, brand)
     end
 
     protected
@@ -140,6 +135,16 @@ module CreditCardValidations
 
       def has_luhn_check_rule?(key)
         !brands[key].fetch(:options, {}).fetch(:skip_luhn, false)
+      end
+
+      # Class-level CVV check: validates a code against an explicit brand,
+      # without needing a Detector instance. Useful when only the brand is
+      # known (form input bound to a brand select, separate CVV field, etc.).
+      def valid_cvv?(code, brand)
+        return false if code.nil? || brand.nil? || !code.to_s.match?(/\A\d+\z/)
+        spec = brands.dig(brand, :options, :code)
+        raise Error, "brand #{brand.inspect} has no :code option" if spec.nil?
+        code.to_s.length == spec[:size]
       end
 
       #

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -1,0 +1,51 @@
+require_relative 'test_helper'
+
+describe CreditCardValidations::Card do
+  Card = CreditCardValidations::Card
+  let(:future) { Date.today >> 12 }
+  let(:visa)   { VALID_NUMBERS[:visa].first }
+  let(:amex)   { VALID_NUMBERS[:amex].first }
+
+  it 'is valid with a good PAN, future expiration, matching CVV' do
+    card = Card.new(
+      number: visa,
+      month: future.month, year: future.year,
+      verification_value: '123', name: 'John Smith'
+    )
+    expect(card.valid?).must_equal true
+    expect(card.brand).must_equal :visa
+    expect(card.last_digits).must_equal visa.tr(' -', '')[-4, 4]
+  end
+
+  it 'detects amex and requires a 4-digit CID' do
+    card = Card.new(number: amex, month: future.month, year: future.year, verification_value: '123')
+    expect(card.brand).must_equal :amex
+    expect(card.valid?).must_equal false
+    expect(card.errors[:verification_value]).wont_be_empty
+  end
+
+  it 'rejects an expired card' do
+    past = Date.today << 24
+    card = Card.new(number: visa, month: past.month, year: past.year, verification_value: '123')
+    expect(card.expired?).must_equal true
+    expect(card.valid?).must_equal false
+  end
+
+  it 'rejects an invalid PAN' do
+    card = Card.new(number: '4111111111111110', month: future.month, year: future.year, verification_value: '123')
+    expect(card.valid?).must_equal false
+    expect(card.errors[:number]).wont_be_empty
+  end
+
+  it 'exposes display_number and masked accessor' do
+    card = Card.new(number: visa, month: future.month, year: future.year, verification_value: '123')
+    digits = visa.tr(' -', '')
+    expect(card.display_number).must_equal "#{'*' * (digits.length - 4)}#{digits[-4, 4]}"
+  end
+
+  it 'formats the PAN per brand convention' do
+    card = Card.new(number: amex, month: future.month, year: future.year, verification_value: '1234')
+    digits = amex.tr(' -', '')
+    expect(card.formatted_number).must_equal "#{digits[0,4]} #{digits[4,6]} #{digits[10,5]}"
+  end
+end

--- a/spec/cvv_validator_spec.rb
+++ b/spec/cvv_validator_spec.rb
@@ -1,0 +1,48 @@
+require_relative 'test_helper'
+
+class PaymentForm
+  include ActiveModel::Model
+  attr_accessor :number, :cvv, :other_cvv
+
+  validates :cvv,       credit_card_cvv: { brand_from: :number }, allow_blank: true
+  validates :other_cvv, credit_card_cvv: { brand: :amex },        allow_blank: true
+end
+
+describe ActiveModel::Validations::CreditCardCvvValidator do
+  let(:amex_pan) { VALID_NUMBERS[:amex].first }
+  let(:visa_pan) { VALID_NUMBERS[:visa].first }
+
+  describe ':brand_from option' do
+    it 'requires 4 digits when the linked number is amex' do
+      form = PaymentForm.new(number: amex_pan, cvv: '1234')
+      expect(form.valid?).must_equal true
+
+      form.cvv = '123'
+      expect(form.valid?).must_equal false
+      expect(form.errors[:cvv]).wont_be_empty
+    end
+
+    it 'requires 3 digits when the linked number is visa' do
+      form = PaymentForm.new(number: visa_pan, cvv: '123')
+      expect(form.valid?).must_equal true
+
+      form.cvv = '1234'
+      expect(form.valid?).must_equal false
+    end
+
+    it 'rejects non-digit input' do
+      form = PaymentForm.new(number: visa_pan, cvv: 'abc')
+      expect(form.valid?).must_equal false
+    end
+  end
+
+  describe ':brand option (literal)' do
+    it 'requires 4 digits when brand is :amex' do
+      form = PaymentForm.new(other_cvv: '1234')
+      expect(form.valid?).must_equal true
+
+      form.other_cvv = '123'
+      expect(form.valid?).must_equal false
+    end
+  end
+end

--- a/spec/expiration_validator_spec.rb
+++ b/spec/expiration_validator_spec.rb
@@ -1,0 +1,33 @@
+require_relative 'test_helper'
+
+class ExpiringCard
+  include ActiveModel::Model
+  attr_accessor :expiration
+
+  validates :expiration, credit_card_expiration: true, allow_blank: true
+end
+
+describe ActiveModel::Validations::CreditCardExpirationValidator do
+  let(:future) { (Date.today >> 12).strftime('%m/%y') }
+  let(:past)   { (Date.today << 12).strftime('%m/%y') }
+
+  it 'accepts a future MM/YY date' do
+    expect(ExpiringCard.new(expiration: future).valid?).must_equal true
+  end
+
+  it 'rejects a past MM/YY date' do
+    card = ExpiringCard.new(expiration: past)
+    expect(card.valid?).must_equal false
+    expect(card.errors[:expiration]).wont_be_empty
+  end
+
+  it 'rejects unparseable input' do
+    expect(ExpiringCard.new(expiration: 'garbage').valid?).must_equal false
+    expect(ExpiringCard.new(expiration: '13/27').valid?).must_equal false
+  end
+
+  it 'allows blank input via :allow_blank' do
+    expect(ExpiringCard.new(expiration: nil).valid?).must_equal true
+    expect(ExpiringCard.new(expiration: '').valid?).must_equal true
+  end
+end


### PR DESCRIPTION
## Summary

Three additions that compose into a complete card-validation API surface.

### 1. `ActiveModel::Validations::CreditCardCvvValidator`

```ruby
class Payment
  include ActiveModel::Validations
  attr_accessor :card_number, :cvv

  validates :cvv, credit_card_cvv: { brand_from: :card_number }
  # or, with a literal brand
  validates :cvv, credit_card_cvv: { brand: :amex }
end
```

`:brand_from` infers the expected CVV size from another attribute (the PAN). `:brand` accepts the brand symbol directly. Delegates to `Detector#valid_cvv?`.

### 2. `ActiveModel::Validations::CreditCardExpirationValidator`

```ruby
class Payment
  validates :expiration, credit_card_expiration: true
  # or split month + year
  validates :exp_month, credit_card_expiration: { year_from: :exp_year }
end
```

Delegates to `CreditCardValidations::Expiration`.

### 3. `CreditCardValidations::Card`

```ruby
card = CreditCardValidations::Card.new(
  number: '4111 1111 1111 1111',
  month: 12, year: 2027,
  verification_value: '123',
  name: 'John Smith'
)
card.valid?            # => true
card.brand             # => :visa
card.display_number    # => "************1111"
card.last_digits       # => "1111"
card.expired?          # => false
card.formatted_number  # => "4111 1111 1111 1111"
```

