### PR TITLE
Restructure README for v9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ![Coverage](https://didww.github.io/credit_card_validations/badge.svg)
 
 
-Gem adds validator  to check whether or not a given number actually falls within the ranges of possible numbers prior to performing such verification, and, as such, CreditCardValidations simply verifies that the credit card number provided is well-formed.
+Gem adds a validator to check whether a given number actually falls within the ranges of possible numbers prior to performing verification — `CreditCardValidations` verifies that the credit card number provided is well-formed.
 
-More info about card BIN numbers http://en.wikipedia.org/wiki/Bank_card_number
+More info about card BIN numbers: http://en.wikipedia.org/wiki/Bank_card_number
 
 ## Installation
 
@@ -29,88 +29,136 @@ Or install it yourself as:
 $ gem install credit_card_validations
 ```
 
-## Usage
+## Default brands
 
-
-The following issuing institutes are accepted:
-    
-|    Name   |    Key     | 
----------------------   | ------------| 
-[American Express](http://en.wikipedia.org/wiki/American_Express) | :amex
-[China UnionPay](http://en.wikipedia.org/wiki/China_UnionPay)    | :unionpay 
-[Dankort](http://en.wikipedia.org/wiki/Dankort)      | :dankort
-[Diners Club](http://en.wikipedia.org/wiki/Diners_Club_International)  | :diners   
-[Elo](https://pt.wikipedia.org/wiki/Elo_Participa%C3%A7%C3%B5es_S/A)      | :elo
-[Discover](http://en.wikipedia.org/wiki/Discover_Card) | :discover   
-[Hipercard](http://pt.wikipedia.org/wiki/Hipercard) | :hipercard  
-[JCB](http://en.wikipedia.org/wiki/Japan_Credit_Bureau)  | :jcb
-[Maestro](http://en.wikipedia.org/wiki/Maestro_%28debit_card%29)    | :maestro
-[MasterCard](http://en.wikipedia.org/wiki/MasterCard)  |   :mastercard
-[MIR](http://www.nspk.ru/en/cards-mir/)  |   :mir
-[Rupay](http://en.wikipedia.org/wiki/RuPay) |   :rupay 
-[Solo](http://en.wikipedia.org/wiki/Solo_(debit_card))     | :solo
-[Switch](http://en.wikipedia.org/wiki/Switch_(debit_card)) | :switch 
-[Visa](http://en.wikipedia.org/wiki/Visa_Inc.)      | :visa  
-
-
-
-The following are supported with plugins
+These brands are detected out of the box. They are the international majors that most acquirers, gateways, and payment forms care about:
 
 |    Name   |    Key     |
 ---------------------   | ------------|
-[Cabal](https://en.wikipedia.org/wiki/Cabal_(debit_card)) | :cabal
-[Carnet](https://en.wikipedia.org/wiki/Carnet_(card)) | :carnet
-[Cartes Bancaires](https://en.wikipedia.org/wiki/Cartes_Bancaires) | :cartes_bancaires
-[DinaCard](https://en.wikipedia.org/wiki/DinaCard) | :dinacard
-[Diners Club US](http://en.wikipedia.org/wiki/Diners_Club_International#MasterCard_alliance)  | :diners_us
-[EnRoute](https://en.wikipedia.org/wiki/EnRoute_(credit_card)) | :en_route
-[Girocard](https://en.wikipedia.org/wiki/Girocard) | :girocard
-[Hiper](https://en.wikipedia.org/wiki/Itau_Unibanco) | :hiper
-[Humo](https://en.wikipedia.org/wiki/Humo_(payment_system)) | :humocard
-[Laser](https://en.wikipedia.org/wiki/Laser_%28debit_card%29)      | :laser
-[Mada](https://en.wikipedia.org/wiki/Mada_(payment_system)) | :mada
-[Naranja](https://en.wikipedia.org/wiki/Tarjeta_Naranja) | :naranja
-[Troy](https://en.wikipedia.org/wiki/Troy_(payment_system)) | :troy
-[UATP](https://en.wikipedia.org/wiki/Universal_Air_Travel_Plan) | :uatp
-[Uzcard](https://en.wikipedia.org/wiki/Uzcard) | :uzcard
-[V Pay](https://en.wikipedia.org/wiki/V_Pay) | :vpay
-[Verve](https://en.wikipedia.org/wiki/Verve_(payment_card)) | :verve
-[Voyager](https://en.wikipedia.org/wiki/Voyager_card) | :voyager
+[American Express](http://en.wikipedia.org/wiki/American_Express) | `:amex`
+[China UnionPay](http://en.wikipedia.org/wiki/China_UnionPay) | `:unionpay`
+[Diners Club](http://en.wikipedia.org/wiki/Diners_Club_International) | `:diners`
+[Discover](http://en.wikipedia.org/wiki/Discover_Card) | `:discover`
+[JCB](http://en.wikipedia.org/wiki/Japan_Credit_Bureau) | `:jcb`
+[Maestro](http://en.wikipedia.org/wiki/Maestro_%28debit_card%29) | `:maestro`
+[MasterCard](http://en.wikipedia.org/wiki/MasterCard) | `:mastercard`
+[Visa](http://en.wikipedia.org/wiki/Visa_Inc.) | `:visa`
 
+## Opt-in plugins
 
+Everything else is detected only when its plugin is explicitly required. Plugins add no startup cost, no API surface, and no chance of misdetection to apps that don't accept the brand.
 
-### Examples using string monkey patch
+### Active regional and specialty networks
+
+|    Name   |    Key     |
+---------------------   | ------------|
+[Cabal](https://en.wikipedia.org/wiki/Cabal_(debit_card)) | `:cabal`
+[Carnet](https://en.wikipedia.org/wiki/Carnet_(card)) | `:carnet`
+[Cartes Bancaires](https://en.wikipedia.org/wiki/Cartes_Bancaires) | `:cartes_bancaires`
+[Dankort](http://en.wikipedia.org/wiki/Dankort) | `:dankort`
+[DinaCard](https://en.wikipedia.org/wiki/DinaCard) | `:dinacard`
+[Elo](https://pt.wikipedia.org/wiki/Elo_Participa%C3%A7%C3%B5es_S/A) | `:elo`
+[Girocard](https://en.wikipedia.org/wiki/Girocard) | `:girocard`
+[Hiper](https://en.wikipedia.org/wiki/Itau_Unibanco) | `:hiper`
+[Hipercard](http://pt.wikipedia.org/wiki/Hipercard) | `:hipercard`
+[Humo](https://en.wikipedia.org/wiki/Humo_(payment_system)) | `:humocard`
+[Mada](https://en.wikipedia.org/wiki/Mada_(payment_system)) | `:mada`
+[MIR](http://www.nspk.ru/en/cards-mir/) | `:mir`
+[Naranja](https://en.wikipedia.org/wiki/Tarjeta_Naranja) | `:naranja`
+[RuPay](http://en.wikipedia.org/wiki/RuPay) | `:rupay`
+[Troy](https://en.wikipedia.org/wiki/Troy_(payment_system)) | `:troy`
+[UATP](https://en.wikipedia.org/wiki/Universal_Air_Travel_Plan) | `:uatp`
+[Uzcard](https://en.wikipedia.org/wiki/Uzcard) | `:uzcard`
+[V Pay](https://en.wikipedia.org/wiki/V_Pay) | `:vpay`
+[Verve](https://en.wikipedia.org/wiki/Verve_(payment_card)) | `:verve`
+[Voyager](https://en.wikipedia.org/wiki/Voyager_card) | `:voyager`
+
+### Legacy / withdrawn networks
+
+|    Name   |    Key     | Status |
+---------------------   | ------------| ------|
+[Diners Club US](http://en.wikipedia.org/wiki/Diners_Club_International#MasterCard_alliance) | `:diners_us` | Merged into Discover for US routing in 2008 |
+[EnRoute](https://en.wikipedia.org/wiki/EnRoute_(credit_card)) | `:en_route` | Withdrawn 1989 |
+[Laser](https://en.wikipedia.org/wiki/Laser_%28debit_card%29) | `:laser` | Withdrawn 2014 |
+[Solo](https://en.wikipedia.org/wiki/Solo_(debit_card)) | `:solo` | Withdrawn 2011 |
+[Switch](https://en.wikipedia.org/wiki/Switch_(debit_card)) | `:switch` | Withdrawn 2002 |
+
+### Loading plugins
+
+```ruby
+# in an initializer or before first use
+require 'credit_card_validations/plugins/mir'
+require 'credit_card_validations/plugins/elo'
+require 'credit_card_validations/plugins/hipercard'
+# ... whichever brands the app actually accepts
+```
+
+## Migrating from v8.x → v9.0
+
+Seven brands moved from the default brand set to opt-in plugins in v9.0. The auto-require shim keeps existing code working for one major version with a one-time deprecation warning per brand.
+
+| Brand | Status | Auto-loaded until |
+|---|---|---|
+| `:dankort` | Active (Denmark) | v10.0 |
+| `:elo` | Active (Brazil) | v10.0 |
+| `:hipercard` | Active (Brazil) | v10.0 |
+| `:mir` | Active (Russia) | v10.0 |
+| `:rupay` | Active (India) | v10.0 |
+| `:solo` | Withdrawn 2011 | v10.0 |
+| `:switch` | Withdrawn 2002 | v10.0 |
+
+If your code references any of these brands by symbol, add the matching `require` to your initializer to silence the warning and survive v10:
+
+```ruby
+# config/initializers/credit_card_validations.rb
+require 'credit_card_validations/plugins/mir'
+require 'credit_card_validations/plugins/elo'
+# ...
+```
+
+When v10 lands, the auto-load disappears. Code that names these brands without a matching `require` will see them as unknown — `Detector#brand` returns `nil`, predicate methods (`mir?`, `elo?`, …) are not defined, and `valid?(:mir)` returns false.
+
+### Other breaking changes in v9.0
+
+- **`Hipercard` cleaned up.** Length changed from 19 to 16 (which is the issued length); legacy `637*` prefixes that actually belong to Hiper were dropped. If you used Hipercard before, your detection now matches the brand's real spec.
+- **`Discover` cleaned up.** Diners-only prefixes (`300-305, 3095, 36, 38, 39`) were dropped from Discover. Diners cards now correctly detect as `:diners` instead of `:discover`. Apps that branched on `:discover` for routing should branch on `[:diners, :discover]`.
+- **`Luhn.valid?` is now strict.** It accepts a digit-only string and returns `false` for `nil`, empty input, or any non-digit character. User-facing input handling moved into `Detector#initialize`, which strips whitespace and dashes before delegating.
+- **Brand YAML is loaded via `YAML.safe_load_file`.** Custom brand sources may need to declare `permitted_classes: [Symbol]` if they relied on extra Ruby objects.
+
+## Usage
+
+### String monkey patch
 
 ```ruby
 require 'credit_card_validations/string'
-'5274 5763 9425 9961'.credit_card_brand   #=> :mastercard
-'5274 5763 9425 9961'.credit_card_brand_name   #=> "MasterCard"
-'5274 5763 9425 9961'.valid_credit_card_brand?(:mastercard, :visa) #=> true
-'5274 5763 9425 9961'.valid_credit_card_brand?(:amex) #=> false
-'5274 5763 9425 9961'.valid_credit_card_brand?('MasterCard') #=> true
+'5274 5763 9425 9961'.credit_card_brand                                #=> :mastercard
+'5274 5763 9425 9961'.credit_card_brand_name                           #=> "MasterCard"
+'5274 5763 9425 9961'.valid_credit_card_brand?(:mastercard, :visa)     #=> true
+'5274 5763 9425 9961'.valid_credit_card_brand?(:amex)                  #=> false
+'5274 5763 9425 9961'.valid_credit_card_brand?('MasterCard')           #=> true
 ```
 
-### ActiveModel support
+### ActiveModel validators
 
-only for certain brands
+Restrict to a brand list:
 
 ```ruby
 class CreditCardModel
   attr_accessor :number
   include ActiveModel::Validations
-  validates :number, credit_card_number: {brands: [:amex, :maestro]}
+  validates :number, credit_card_number: { brands: [:amex, :maestro] }
 end
 ```
 
-for all known brands
+Accept any known brand:
 
 ```ruby
 validates :number, presence: true, credit_card_number: true
 ```
 
-### CVV and Expiration validators
+### CVV validator
 
-CVV against a brand pulled from another attribute:
+CVV against a brand pulled from another attribute (the PAN):
 
 ```ruby
 class Payment
@@ -128,14 +176,15 @@ CVV against a literal brand:
 validates :cvv, credit_card_cvv: { brand: :amex }
 ```
 
-Expiration held in a single string attribute (`MM/YY`, `MM/YYYY`, `MMYY`, ...):
+### Expiration validator
+
+A single string attribute (`MM/YY`, `MM/YYYY`, `MMYY`, ...):
 
 ```ruby
 validates :expiration, credit_card_expiration: true
 ```
 
-When the form uses two separate fields (month and year dropdowns), use the
-`Expiration` class directly in a `validate` block:
+Two separate fields (typical month + year dropdowns) — use the `Expiration` class in a `validate` block:
 
 ```ruby
 class Payment
@@ -148,10 +197,9 @@ class Payment
 end
 ```
 
-### CreditCardValidations::Card
+### `CreditCardValidations::Card`
 
-A composite model wrapping `Detector` and `Expiration` behind a single
-ActiveModel-aware object:
+A composite model wrapping `Detector` and `Expiration` behind a single ActiveModel-aware object:
 
 ```ruby
 card = CreditCardValidations::Card.new(
@@ -168,44 +216,46 @@ card.expired?          # => false
 card.formatted_number  # => "4111 1111 1111 1111"
 ```
 
-### Examples using CreditCardValidations::Detector class
+### Using `Detector` directly
 
 ```ruby
-number = "4111111111111111"
+number   = '4111111111111111'
 detector = CreditCardValidations::Detector.new(number)
-detector.brand #:visa
-detector.visa? #true
-detector.valid?(:mastercard,:maestro) #false
-detector.valid?(:visa, :mastercard) #true
-detector.issuer_category  #"Banking and financial"
+
+detector.brand                          # => :visa
+detector.visa?                          # => true
+detector.valid?(:mastercard, :maestro)  # => false
+detector.valid?(:visa, :mastercard)     # => true
+detector.issuer_category                # => "Banking and financial"
+detector.last4                          # => "1111"
+detector.masked                         # => "************1111"
+detector.formatted                      # => "4111 1111 1111 1111"
+detector.possible_brands                # => [:visa]   (during live input)
+detector.valid_cvv?('123')              # => true
 ```
 
-### Also You can add your own brand rules to detect other credit card brands/types
-passing name,length(integer/array of integers) and prefix(string/array of strings)
-Example
+### Adding a custom brand at runtime
 
 ```ruby
-CreditCardValidations.add_brand(:voyager, {length: 15, prefixes: '86'})
-voyager_test_card_number = '869926275400212'
-CreditCardValidations::Detector.new(voyager_test_card_number).brand #:voyager
-CreditCardValidations::Detector.new(voyager_test_card_number).voyager? #true
+CreditCardValidations.add_brand(:voyager, { length: 15, prefixes: '86' })
+CreditCardValidations::Detector.new('869926275400212').voyager?  # => true
 ```
 
-### Remove brands also supported
+### Removing a brand at runtime
 
 ```ruby
 CreditCardValidations::Detector.delete_brand(:maestro)
 ```
 
-### Check luhn
+### Luhn check
 
 ```ruby
-CreditCardValidations::Detector.new(@credit_card_number).valid_luhn?
-#or
-CreditCardValidations::Luhn.valid?(@credit_card_number)
+CreditCardValidations::Detector.new(number).valid_luhn?
+# or, on a clean digit string:
+CreditCardValidations::Luhn.valid?(number)
 ```
 
-### Generate credit card numbers that pass validation
+### Generating Luhn-valid test numbers
 
 ```ruby
 CreditCardValidations::Factory.random(:amex)
@@ -214,41 +264,15 @@ CreditCardValidations::Factory.random(:maestro)
 # => "6010430241237266856"
 ```
 
-### Plugins
+## Configuration
+
+To override the default brand source, copy [the bundled `brands.yaml`](https://github.com/didww/credit_card_validations/blob/master/lib/data/brands.yaml), edit it, and point the gem at it in a Rails initializer:
 
 ```ruby
-require 'credit_card_validations/plugins/en_route'
-require 'credit_card_validations/plugins/laser'
-require 'credit_card_validations/plugins/diners_us'
-
-require 'credit_card_validations/plugins/cabal'
-require 'credit_card_validations/plugins/carnet'
-require 'credit_card_validations/plugins/cartes_bancaires'
-require 'credit_card_validations/plugins/dinacard'
-require 'credit_card_validations/plugins/girocard'
-require 'credit_card_validations/plugins/hiper'
-require 'credit_card_validations/plugins/humocard'
-require 'credit_card_validations/plugins/mada'
-require 'credit_card_validations/plugins/naranja'
-require 'credit_card_validations/plugins/troy'
-require 'credit_card_validations/plugins/uatp'
-require 'credit_card_validations/plugins/uzcard'
-require 'credit_card_validations/plugins/verve'
-require 'credit_card_validations/plugins/voyager'
-require 'credit_card_validations/plugins/vpay'
+CreditCardValidations.configure do |config|
+  config.source = '/path/to/my_brands.yml'
+end
 ```
-
-
-### Configuration
-
-In order to override default data source you can copy [original one](https://github.com/didww/credit_card_validations/blob/master/lib/data/brands.yaml) , change it and configure during rails initializer
-
-```ruby
- CreditCardValidations.configure do |config|
-      config.source = '/path/to/my_brands.yml'
- end
-```
-
 
 ## Contributing
 
@@ -256,7 +280,4 @@ In order to override default data source you can copy [original one](https://git
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
-
-
-
+5. Open a Pull Request


### PR DESCRIPTION
## Summary

README rewrite for the v9.0 brand split.

### Brand tables restructured

- **Default brands** (8): Visa, Mastercard, Amex, Discover, Maestro, JCB, Diners, UnionPay
- **Opt-in plugins — active** (21): regional networks (Cabal, Carnet, Cartes Bancaires, Dankort, DinaCard, Elo, Girocard, Hiper, Hipercard, Humo, Mada, MIR, Naranja, RuPay, Troy, UATP, Uzcard, V Pay, Verve, Voyager) — alphabetized
- **Opt-in plugins — legacy/withdrawn** (5): Diners Club US, EnRoute, Laser, Solo, Switch — each with its withdrawal/migration note

### New migration guide

Explicit `Migrating from v8.x → v9.0` section: which 7 brands moved (mir, rupay, elo, dankort, hipercard, solo, switch), the auto-require shim behavior, when it disappears (v10), and the one-liner each user needs in their initializer.

### Other v9 breaking changes called out

Dedicated section covers Hipercard length/prefix cleanup, Discover/Diners separation, strict Luhn, and YAML.safe_load.

### Usage examples updated

- New CVV validator (`brand` and `brand_from` options)
- New Expiration validator + the `validate` block pattern for split month/year fields
- New `CreditCardValidations::Card` composite model
- `Detector` example expanded with `#last4`, `#masked`, `#formatted`, `#possible_brands`, `#valid_cvv?`
