### PR TITLE
Point changelog_uri to GitHub releases

### DIFF
--- a/credit_card_validations.gemspec
+++ b/credit_card_validations.gemspec
@@ -15,12 +15,11 @@ Gem::Specification.new do |gem|
 
   gem.metadata    = {
     'bug_tracker_uri'   => 'https://github.com/didww/credit_card_validations/issues',
-    'changelog_uri'     => 'https://github.com/didww/credit_card_validations/blob/master/Changelog.md',
+    'changelog_uri'     => 'https://github.com/didww/credit_card_validations/releases',
     'source_code_uri'   => 'https://github.com/didww/credit_card_validations'
   }
 
   gem.files = Dir.glob('lib/**/*') + [
-    'Changelog.md',
     'LICENSE.txt',
     'README.md'
   ]


### PR DESCRIPTION
## Summary
- Switch `changelog_uri` metadata from the no-longer-tracked `Changelog.md` to the GitHub Releases page.
- Drop `Changelog.md` from `gem.files` so `gem build` stops failing on the missing file.

## Test plan
- [x] `gem build credit_card_validations.gemspec` succeeds.