### PR TITLE
Set required_ruby_version to >= 3.1

### DIFF
--- a/credit_card_validations.gemspec
+++ b/credit_card_validations.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'gem should be used for credit card numbers validation, card brands detections, luhn checks'
   gem.homepage      = 'http://didww.github.io/credit_card_validations/'
   gem.license       = 'MIT'
+  gem.required_ruby_version = '>= 3.1'
 
   gem.metadata    = {
     'bug_tracker_uri'   => 'https://github.com/didww/credit_card_validations/issues',


### PR DESCRIPTION
## Summary
- Declare `required_ruby_version = '>= 3.1'` so `gem build` no longer warns and the published gem advertises the same floor as the CI matrix (3.1–3.4).
