### PR TITLE
Drop EOL Ruby 3.1, 3.2 and Rails 7.1 from CI; add Ruby 4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,25 +17,15 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - 3.1
-        - 3.2
         - 3.3
         - 3.4
+        - '4.0'
         rails:
-        - '7.1.0'
-        - '7.2.0'
-        - '8.0.0'
+        - '7.2.3.1'
+        - '8.0.2.1'
         - '8.1.0'
         - 'edge'
         exclude:
-        - ruby-version: 3.1
-          rails: '8.0.0'
-        - ruby-version: 3.1
-          rails: '8.1.0'
-        - ruby-version: 3.1
-          rails: 'edge'
-        - ruby-version: 3.2
-          rails: 'edge'
         - ruby-version: 3.3
           rails: 'edge'
     continue-on-error: ${{ matrix.rails == 'edge' }}

--- a/credit_card_validations.gemspec
+++ b/credit_card_validations.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary       = 'gem should be used for credit card numbers validation, card brands detections, luhn checks'
   gem.homepage      = 'http://didww.github.io/credit_card_validations/'
   gem.license       = 'MIT'
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.3'
 
   gem.metadata    = {
     'bug_tracker_uri'   => 'https://github.com/didww/credit_card_validations/issues',


### PR DESCRIPTION
## Summary

Updates the CI Ruby matrix to match the current Ruby branch support status from https://www.ruby-lang.org/en/downloads/branches/.

| Version | Status as of June 2026 | In matrix |
|---|---|---|
| 4.0 | Normal maintenance (released Dec 2025) | **added** |
| 3.4 | Normal maintenance | kept |
| 3.3 | Security maintenance (EOL March 2027) | kept |
| 3.2 | EOL April 2026 | **removed** |
| 3.1 | EOL March 2025 | **removed** |

Also bumps `required_ruby_version` in the gemspec from `>= 3.1` to `>= 3.3`, and drops the matrix `exclude` entries that no longer apply.

